### PR TITLE
"pattern" is deprecated

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 anh_taggable_search:
-    pattern:  /_taggable/search.json
+    path:  /_taggable/search.json
     defaults: { _controller: AnhTaggableBundle:Default:search }


### PR DESCRIPTION
The pattern setting for a route has been deprecated in favor of path
https://github.com/symfony/Routing/blob/master/CHANGELOG.md#220