### PR TITLE
setDefaults Is deprecated

### DIFF
--- a/AnhTaggableBundle.php
+++ b/AnhTaggableBundle.php
@@ -9,6 +9,7 @@ class AnhTaggableBundle extends Bundle
     public static function getRequiredBundles()
     {
         return array(
+            'Anh\DoctrineResourceBundle\AnhDoctrineResourceBundle',
             'Sp\BowerBundle\SpBowerBundle',
         );
     }

--- a/DependencyInjection/AnhTaggableExtension.php
+++ b/DependencyInjection/AnhTaggableExtension.php
@@ -71,5 +71,18 @@ class AnhTaggableExtension extends Extension implements PrependExtensionInterfac
                 'AnhTaggableBundle' => null
             )
         ));
+
+        $container->prependExtensionConfig('anh_doctrine_resource', array(
+            'resources' => array(
+                'anh_taggable.tag' => array(
+                    'model' => '%anh_taggable.entity.tag.class%',
+                    'driver' => 'orm',
+                ),
+                'anh_taggable.tagging' => array(
+                    'model' => '%anh_taggable.entity.tagging.class%',
+                    'driver' => 'orm',
+                ),
+            )
+        ));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 
     "require": {
         "anh/doctrine-extensions-taggable": "~1.0",
+        "anh/doctrine-resource-bundle": "0.2.*",
         "sp/bower-bundle": "~0.9"
     },
 
@@ -27,7 +28,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
 
     "require": {
-        "anh/doctrine-extensions-taggable": "~1.0",
+        "anh/doctrine-extensions-taggable": "~1.1",
         "anh/doctrine-resource-bundle": "0.2.*",
         "sp/bower-bundle": "~0.9"
     },


### PR DESCRIPTION
In Symfony 2.7, the setDefaultOptions() method of AbstractType and AbstractExtensionType has been deprecated in favor of the new configureOptions() method

http://symfony.com/blog/new-in-symfony-2-7-form-and-validator-updates